### PR TITLE
escape literal \n with character

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -170,7 +170,8 @@ public class DefaultCodegen {
     @SuppressWarnings("static-method")
     public String escapeText(String input) {
         if (input != null) {
-            return StringEscapeUtils.escapeJava(input).replace("\\/", "/");
+            StringEscapeUtils.escapeJava(input);
+            input = input.replace("\\/", "/").replace("\\n", "\n");
         }
         return input;
     }


### PR DESCRIPTION
Due to the `escapeJava()` call, I was getting `\n` escaped in a String which would make its way into Markdown documentation and look ugly. I replaced the "\n" strings with a '\n\ character in order to fix this. My swagger schema is in `yaml` and we have multi-line blocks of documentation. 

This may be useful to people in a similar situation. 